### PR TITLE
Add 4-byte length prefix when converting byte array to vector 

### DIFF
--- a/program/src/processor/create_credential.rs
+++ b/program/src/processor/create_credential.rs
@@ -15,7 +15,7 @@ use solana_program::pubkey::Pubkey as SolanaPubkey;
 use crate::{
     constants::CREDENTIAL_SEED,
     error::AttestationServiceError,
-    processor::create_pda_account,
+    processor::{create_pda_account, to_serialized_vec},
     state::{load_signer, load_system_account, load_system_program, Credential},
 };
 
@@ -75,7 +75,7 @@ pub fn process_create_credential(
 
     let credential = Credential {
         authority: *authority_info.key(),
-        name: name.to_vec(),
+        name: to_serialized_vec(name),
         authorized_signers: signers,
     };
     let mut credential_data = credential_info.try_borrow_mut_data()?;
@@ -123,7 +123,7 @@ impl CreateCredentialArgs<'_> {
         unsafe {
             // use length of name to determine offset of Vec<Pubkey>
             let name_offset_including_length = *(self.raw as *const u32) + 4; // add for the length field
-            // Length of Vec<Pubkey>
+                                                                              // Length of Vec<Pubkey>
             let signers_length =
                 *(self.raw.add(name_offset_including_length as usize) as *const u32);
 

--- a/program/src/processor/create_schema.rs
+++ b/program/src/processor/create_schema.rs
@@ -13,10 +13,9 @@ use solana_program::pubkey::Pubkey as SolanaPubkey;
 use crate::{
     constants::SCHEMA_SEED,
     error::AttestationServiceError,
+    processor::{create_pda_account, to_serialized_vec},
     state::{load_system_account, load_system_program, Schema},
 };
-
-use super::create_pda_account;
 
 #[inline(always)]
 pub fn process_create_schema(
@@ -77,9 +76,9 @@ pub fn process_create_schema(
 
     let schema = Schema {
         credential: *credential_info.key(),
-        name: name.to_vec(),
-        description: description.to_vec(),
-        data_schema: data_schema.to_vec(),
+        name: to_serialized_vec(name),
+        description: to_serialized_vec(description),
+        data_schema: to_serialized_vec(data_schema),
         is_paused: false,
     };
     let mut schema_data = schema_info.try_borrow_mut_data()?;

--- a/program/src/processor/shared/data_utils.rs
+++ b/program/src/processor/shared/data_utils.rs
@@ -1,0 +1,8 @@
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+// Serializes an array of bytes to Vector representation by prepending array length.
+pub fn to_serialized_vec(data: &[u8]) -> Vec<u8> {
+    [(data.len() as u32).to_le_bytes().as_slice(), data].concat()
+}

--- a/program/src/processor/shared/mod.rs
+++ b/program/src/processor/shared/mod.rs
@@ -1,3 +1,5 @@
+pub mod data_utils;
 pub mod pda_utils;
 
+pub use data_utils::*;
 pub use pda_utils::*;

--- a/program/src/state/credential.rs
+++ b/program/src/state/credential.rs
@@ -30,7 +30,6 @@ impl Credential {
         data.extend_from_slice(self.authority.as_ref());
 
         // Name encoding
-        data.extend_from_slice(&(self.name.len() as u32).to_le_bytes());
         data.extend_from_slice(self.name.as_ref());
 
         // Authorized signers encoding

--- a/program/src/state/schema.rs
+++ b/program/src/state/schema.rs
@@ -29,16 +29,9 @@ impl Schema {
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut data = Vec::new();
         data.extend_from_slice(self.credential.as_ref());
-
-        data.extend_from_slice(&(self.name.len() as u32).to_le_bytes());
         data.extend_from_slice(self.name.as_ref());
-
-        data.extend_from_slice(&(self.description.len() as u32).to_le_bytes());
         data.extend_from_slice(self.description.as_ref());
-
-        data.extend_from_slice(&(self.data_schema.len() as u32).to_le_bytes());
         data.extend_from_slice(self.data_schema.as_ref());
-
         data.extend_from_slice(&[self.is_paused as u8]);
 
         data


### PR DESCRIPTION
Add 4-byte length prefix when converting byte array to vector for storing in temporary structs.