### PR TITLE
fix: Encode addresses in PDA derivation and add tests

### DIFF
--- a/clients/typescript/src/pdas.ts
+++ b/clients/typescript/src/pdas.ts
@@ -1,4 +1,4 @@
-import { Address, getProgramDerivedAddress } from "@solana/kit";
+import { Address, getAddressEncoder, getProgramDerivedAddress } from "@solana/kit";
 import { SOLANA_ATTESTATION_SERVICE_PROGRAM_ADDRESS } from "./generated/programs";
 
 export const ATTESTATION_SEED = "attestation";
@@ -51,7 +51,7 @@ export const deriveCredentialPda = ({
 }) =>
   getProgramDerivedAddress({
     programAddress: SOLANA_ATTESTATION_SERVICE_PROGRAM_ADDRESS,
-    seeds: [CREDENTIAL_SEED, authority, name],
+    seeds: [CREDENTIAL_SEED, getAddressEncoder().encode(authority), name],
   });
 
 /**
@@ -74,7 +74,7 @@ export const deriveSchemaPda = ({
   const versionSeed = Uint8Array.from([version]);
   return getProgramDerivedAddress({
     programAddress: SOLANA_ATTESTATION_SERVICE_PROGRAM_ADDRESS,
-    seeds: [SCHEMA_SEED, credential, name, versionSeed],
+    seeds: [SCHEMA_SEED, getAddressEncoder().encode(credential), name, versionSeed],
   });
 };
 
@@ -94,11 +94,13 @@ export const deriveAttestationPda = ({
   credential: Address;
   schema: Address;
   nonce: Address;
-}) =>
-  getProgramDerivedAddress({
+}) => {
+  const addressEncoder = getAddressEncoder();
+  return getProgramDerivedAddress({
     programAddress: SOLANA_ATTESTATION_SERVICE_PROGRAM_ADDRESS,
-    seeds: [ATTESTATION_SEED, credential, schema, nonce],
+    seeds: [ATTESTATION_SEED, addressEncoder.encode(credential), addressEncoder.encode(schema), addressEncoder.encode(nonce)],
   });
+}
 
 /* PDAs for tokenization */
 
@@ -110,7 +112,7 @@ export const deriveAttestationPda = ({
 export const deriveSchemaMintPda = ({ schema }: { schema: Address }) =>
   getProgramDerivedAddress({
     programAddress: SOLANA_ATTESTATION_SERVICE_PROGRAM_ADDRESS,
-    seeds: [SCHEMA_MINT_SEED, schema],
+    seeds: [SCHEMA_MINT_SEED, getAddressEncoder().encode(schema)],
   });
 
 /**
@@ -125,5 +127,5 @@ export const deriveAttestationMintPda = ({
 }) =>
   getProgramDerivedAddress({
     programAddress: SOLANA_ATTESTATION_SERVICE_PROGRAM_ADDRESS,
-    seeds: [ATTESTATION_MINT_SEED, attestation],
+    seeds: [ATTESTATION_MINT_SEED, getAddressEncoder().encode(attestation)],
   });

--- a/clients/typescript/test/utils.ts
+++ b/clients/typescript/test/utils.ts
@@ -1,6 +1,8 @@
 import { assert } from "chai";
 import { getSchemaDecoder } from "../src/generated";
 import { convertSasSchemaToBorshSchema } from "../src/utils";
+import { Address, address, ProgramDerivedAddressBump } from "@solana/kit";
+import { deriveAttestationMintPda, deriveAttestationPda, deriveCredentialPda, deriveSchemaMintPda, deriveSchemaPda } from "../src";
 
 describe("Utils", () => {
   const schemaAccountBytes = Uint8Array.from([
@@ -26,4 +28,53 @@ describe("Utils", () => {
       assert.deepEqual(testData, deserialized);
     });
   });
+  describe("pda derivation", () => {
+    it("should derive a credential PDA", async () => {
+      const issuer = address('tbFevHibEdBNFJfZ7xKC8k1th8pt2YPEXTk4sGMxCGa');
+      const credentialName = 'test';
+      const expectedPda = ['CdUAYGvNc7NdtNgXmxTXoUWR5NjpcU4Za4vtoP2AVZD4', 255] as [Address<string>, ProgramDerivedAddressBump];
+      const testPda = await deriveCredentialPda({ authority: issuer, name: credentialName })
+      assert.deepEqual(testPda, expectedPda);
+    });
+    it("should derive a schema PDA", async () => {
+      const credential = address('2zHazqL3MVayNGkDrTmAC7VsvP5QrSYfiyA7uf29Usmd');
+      const schemaName = 'test';
+      const version = 1;
+      const expectedPda = ['bD7cVGpuTHY43fxtRoqJYi58U6Yi3kMyVck2DyZZRKq', 255] as [Address<string>, ProgramDerivedAddressBump];
+      const testPda = await deriveSchemaPda({
+        credential,
+        version,
+        name: schemaName
+      })
+      assert.deepEqual(testPda, expectedPda);
+    });
+    it("should derive an attestation PDA", async () => {
+      const credential = address('G6QmvUp3a1Kv9rX2LqHDH8AWcKD8yaufcoXEB1h6SzN8');
+      const schema = address('GSwz99vWPKnePyeYTM5iionEfArVmfrufV4AaV4SecTH');
+      const nonce = address('Bdf3cgpzgboZq95T4AVYNxuYGDVE4pwLNQBhQ2ob8CoG');
+      const expectedPda = ['CnhgnrLiawRWitfjrrUfWdR2jpwKbKGDccbk3ne171iu', 255] as [Address<string>, ProgramDerivedAddressBump];
+      const testPda = await deriveAttestationPda({
+        credential,
+        schema,
+        nonce
+      })
+      assert.deepEqual(testPda, expectedPda);
+    });
+    it("should derive a schema mint PDA", async () => {
+      const schema = address('GCVt9SmgLF8bgEVwZAhQ9A2skwj5TvEnyn8Z7eUm583E');
+      const expectedPda = ['9JLQQK3zeEjiq2AJ1XPN765bYnLrBWJSFfyjDwdSMmyN', 245] as [Address<string>, ProgramDerivedAddressBump];
+      const testPda = await deriveSchemaMintPda({
+        schema,
+      })
+      assert.deepEqual(testPda, expectedPda);
+    });
+    it("should derive an attestation mint PDA", async () => {
+      const attestation = address('3z8EuPHrzhfVWuDomSGjU13ABDgQC75DMHoDNBgxdzKR');
+      const expectedPda = ['61FeMtSXR8H22fodXNrTkwmrSmBuTNcAvKzZXvZRPMkX', 253] as [Address<string>, ProgramDerivedAddressBump];
+      const testPda = await deriveAttestationMintPda({
+        attestation,
+      })
+      assert.deepEqual(testPda, expectedPda);
+    });
+  })
 });


### PR DESCRIPTION
- Updated PDA derivation functions in `pdas.ts` to encode address seeds using getAddressEncoder(). 
- Added unit tests for all PDA derivation functions in `utils.ts` to ensure correct output and bump values.

### Issue
The Solana Kit PDA derivation helper, [`getProgramDerivedAddress` ](https://github.com/anza-xyz/kit/blob/c9a9ded3a4428bb61b9d579e29f2838518b18294/packages/addresses/src/program-derived-address.ts#L110
) does not handle address encoding for seeds, so we need to encode the addresses received before calling it.

### Alternatives
Alternatively we could modify the helpers to accept encoded data and require the client to encode the address before passing into the helper functions.

Fixes #68 (this issue report uses a combination of kit and web3.js, but the issue reflected is not related to web3.js).