### PR TITLE
fix: use Token 2022 as default and add missing program defaults

### DIFF
--- a/clients/rust/src/generated/instructions/close_attestation.rs
+++ b/clients/rust/src/generated/instructions/close_attestation.rs
@@ -101,9 +101,9 @@ impl Default for CloseAttestationInstructionData {
 ///   1. `[signer]` authority
 ///   2. `[]` credential
 ///   3. `[writable]` attestation
-///   4. `[]` event_authority
+///   4. `[optional]` event_authority (default to `DzSpKpST2TSyrxokMXchFz3G2yn5WEGoxzpGEUDjCX4g`)
 ///   5. `[optional]` system_program (default to `11111111111111111111111111111111`)
-///   6. `[]` attestation_program
+///   6. `[optional]` attestation_program (default to `22zoJMtdu4tQc2PzL74ZUT7FrwgB1Udec8DdW4yw4BdG`)
 #[derive(Clone, Debug, Default)]
 pub struct CloseAttestationBuilder {
     payer: Option<solana_program::pubkey::Pubkey>,
@@ -141,6 +141,7 @@ impl CloseAttestationBuilder {
         self.attestation = Some(attestation);
         self
     }
+    /// `[optional account, default to 'DzSpKpST2TSyrxokMXchFz3G2yn5WEGoxzpGEUDjCX4g']`
     #[inline(always)]
     pub fn event_authority(
         &mut self,
@@ -155,6 +156,7 @@ impl CloseAttestationBuilder {
         self.system_program = Some(system_program);
         self
     }
+    /// `[optional account, default to '22zoJMtdu4tQc2PzL74ZUT7FrwgB1Udec8DdW4yw4BdG']`
     #[inline(always)]
     pub fn attestation_program(
         &mut self,
@@ -188,13 +190,15 @@ impl CloseAttestationBuilder {
             authority: self.authority.expect("authority is not set"),
             credential: self.credential.expect("credential is not set"),
             attestation: self.attestation.expect("attestation is not set"),
-            event_authority: self.event_authority.expect("event_authority is not set"),
+            event_authority: self.event_authority.unwrap_or(solana_program::pubkey!(
+                "DzSpKpST2TSyrxokMXchFz3G2yn5WEGoxzpGEUDjCX4g"
+            )),
             system_program: self
                 .system_program
                 .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
-            attestation_program: self
-                .attestation_program
-                .expect("attestation_program is not set"),
+            attestation_program: self.attestation_program.unwrap_or(solana_program::pubkey!(
+                "22zoJMtdu4tQc2PzL74ZUT7FrwgB1Udec8DdW4yw4BdG"
+            )),
         };
 
         accounts.instruction_with_remaining_accounts(&self.__remaining_accounts)

--- a/clients/rust/src/generated/instructions/close_tokenized_attestation.rs
+++ b/clients/rust/src/generated/instructions/close_tokenized_attestation.rs
@@ -125,13 +125,13 @@ impl Default for CloseTokenizedAttestationInstructionData {
 ///   1. `[signer]` authority
 ///   2. `[]` credential
 ///   3. `[writable]` attestation
-///   4. `[]` event_authority
+///   4. `[optional]` event_authority (default to `DzSpKpST2TSyrxokMXchFz3G2yn5WEGoxzpGEUDjCX4g`)
 ///   5. `[optional]` system_program (default to `11111111111111111111111111111111`)
-///   6. `[]` attestation_program
+///   6. `[optional]` attestation_program (default to `22zoJMtdu4tQc2PzL74ZUT7FrwgB1Udec8DdW4yw4BdG`)
 ///   7. `[writable]` attestation_mint
 ///   8. `[]` sas_pda
 ///   9. `[writable]` attestation_token_account
-///   10. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
+///   10. `[optional]` token_program (default to `TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb`)
 #[derive(Clone, Debug, Default)]
 pub struct CloseTokenizedAttestationBuilder {
     payer: Option<solana_program::pubkey::Pubkey>,
@@ -173,6 +173,7 @@ impl CloseTokenizedAttestationBuilder {
         self.attestation = Some(attestation);
         self
     }
+    /// `[optional account, default to 'DzSpKpST2TSyrxokMXchFz3G2yn5WEGoxzpGEUDjCX4g']`
     #[inline(always)]
     pub fn event_authority(
         &mut self,
@@ -187,6 +188,7 @@ impl CloseTokenizedAttestationBuilder {
         self.system_program = Some(system_program);
         self
     }
+    /// `[optional account, default to '22zoJMtdu4tQc2PzL74ZUT7FrwgB1Udec8DdW4yw4BdG']`
     #[inline(always)]
     pub fn attestation_program(
         &mut self,
@@ -219,7 +221,7 @@ impl CloseTokenizedAttestationBuilder {
         self.attestation_token_account = Some(attestation_token_account);
         self
     }
-    /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
+    /// `[optional account, default to 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb']`
     #[inline(always)]
     pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
@@ -250,20 +252,22 @@ impl CloseTokenizedAttestationBuilder {
             authority: self.authority.expect("authority is not set"),
             credential: self.credential.expect("credential is not set"),
             attestation: self.attestation.expect("attestation is not set"),
-            event_authority: self.event_authority.expect("event_authority is not set"),
+            event_authority: self.event_authority.unwrap_or(solana_program::pubkey!(
+                "DzSpKpST2TSyrxokMXchFz3G2yn5WEGoxzpGEUDjCX4g"
+            )),
             system_program: self
                 .system_program
                 .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
-            attestation_program: self
-                .attestation_program
-                .expect("attestation_program is not set"),
+            attestation_program: self.attestation_program.unwrap_or(solana_program::pubkey!(
+                "22zoJMtdu4tQc2PzL74ZUT7FrwgB1Udec8DdW4yw4BdG"
+            )),
             attestation_mint: self.attestation_mint.expect("attestation_mint is not set"),
             sas_pda: self.sas_pda.expect("sas_pda is not set"),
             attestation_token_account: self
                 .attestation_token_account
                 .expect("attestation_token_account is not set"),
             token_program: self.token_program.unwrap_or(solana_program::pubkey!(
-                "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
             )),
         };
 

--- a/clients/rust/src/generated/instructions/create_tokenized_attestation.rs
+++ b/clients/rust/src/generated/instructions/create_tokenized_attestation.rs
@@ -163,8 +163,8 @@ pub struct CreateTokenizedAttestationInstructionArgs {
 ///   8. `[]` sas_pda
 ///   9. `[writable]` recipient_token_account
 ///   10. `[]` recipient
-///   11. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
-///   12. `[]` associated_token_program
+///   11. `[optional]` token_program (default to `TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb`)
+///   12. `[optional]` associated_token_program (default to `ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL`)
 #[derive(Clone, Debug, Default)]
 pub struct CreateTokenizedAttestationBuilder {
     payer: Option<solana_program::pubkey::Pubkey>,
@@ -264,12 +264,13 @@ impl CreateTokenizedAttestationBuilder {
         self.recipient = Some(recipient);
         self
     }
-    /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
+    /// `[optional account, default to 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb']`
     #[inline(always)]
     pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
+    /// `[optional account, default to 'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL']`
     #[inline(always)]
     pub fn associated_token_program(
         &mut self,
@@ -350,11 +351,11 @@ impl CreateTokenizedAttestationBuilder {
                 .expect("recipient_token_account is not set"),
             recipient: self.recipient.expect("recipient is not set"),
             token_program: self.token_program.unwrap_or(solana_program::pubkey!(
-                "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
             )),
-            associated_token_program: self
-                .associated_token_program
-                .expect("associated_token_program is not set"),
+            associated_token_program: self.associated_token_program.unwrap_or(
+                solana_program::pubkey!("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"),
+            ),
         };
         let args = CreateTokenizedAttestationInstructionArgs {
             nonce: self.nonce.clone().expect("nonce is not set"),

--- a/clients/rust/src/generated/instructions/emit_event.rs
+++ b/clients/rust/src/generated/instructions/emit_event.rs
@@ -62,7 +62,7 @@ impl Default for EmitEventInstructionData {
 ///
 /// ### Accounts:
 ///
-///   0. `[signer]` event_authority
+///   0. `[signer, optional]` event_authority (default to `DzSpKpST2TSyrxokMXchFz3G2yn5WEGoxzpGEUDjCX4g`)
 #[derive(Clone, Debug, Default)]
 pub struct EmitEventBuilder {
     event_authority: Option<solana_program::pubkey::Pubkey>,
@@ -73,6 +73,7 @@ impl EmitEventBuilder {
     pub fn new() -> Self {
         Self::default()
     }
+    /// `[optional account, default to 'DzSpKpST2TSyrxokMXchFz3G2yn5WEGoxzpGEUDjCX4g']`
     #[inline(always)]
     pub fn event_authority(
         &mut self,
@@ -102,7 +103,9 @@ impl EmitEventBuilder {
     #[allow(clippy::clone_on_copy)]
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
         let accounts = EmitEvent {
-            event_authority: self.event_authority.expect("event_authority is not set"),
+            event_authority: self.event_authority.unwrap_or(solana_program::pubkey!(
+                "DzSpKpST2TSyrxokMXchFz3G2yn5WEGoxzpGEUDjCX4g"
+            )),
         };
 
         accounts.instruction_with_remaining_accounts(&self.__remaining_accounts)

--- a/clients/rust/src/generated/instructions/tokenize_schema.rs
+++ b/clients/rust/src/generated/instructions/tokenize_schema.rs
@@ -121,7 +121,7 @@ pub struct TokenizeSchemaInstructionArgs {
 ///   4. `[writable]` mint
 ///   5. `[]` sas_pda
 ///   6. `[optional]` system_program (default to `11111111111111111111111111111111`)
-///   7. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
+///   7. `[optional]` token_program (default to `TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb`)
 #[derive(Clone, Debug, Default)]
 pub struct TokenizeSchemaBuilder {
     payer: Option<solana_program::pubkey::Pubkey>,
@@ -179,7 +179,7 @@ impl TokenizeSchemaBuilder {
         self.system_program = Some(system_program);
         self
     }
-    /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
+    /// `[optional account, default to 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb']`
     #[inline(always)]
     pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
@@ -221,7 +221,7 @@ impl TokenizeSchemaBuilder {
                 .system_program
                 .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
             token_program: self.token_program.unwrap_or(solana_program::pubkey!(
-                "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
             )),
         };
         let args = TokenizeSchemaInstructionArgs {

--- a/clients/typescript/src/generated/instructions/closeAttestation.ts
+++ b/clients/typescript/src/generated/instructions/closeAttestation.ts
@@ -43,11 +43,15 @@ export type CloseAttestationInstruction<
   TAccountAuthority extends string | IAccountMeta<string> = string,
   TAccountCredential extends string | IAccountMeta<string> = string,
   TAccountAttestation extends string | IAccountMeta<string> = string,
-  TAccountEventAuthority extends string | IAccountMeta<string> = string,
+  TAccountEventAuthority extends
+    | string
+    | IAccountMeta<string> = 'DzSpKpST2TSyrxokMXchFz3G2yn5WEGoxzpGEUDjCX4g',
   TAccountSystemProgram extends
     | string
     | IAccountMeta<string> = '11111111111111111111111111111111',
-  TAccountAttestationProgram extends string | IAccountMeta<string> = string,
+  TAccountAttestationProgram extends
+    | string
+    | IAccountMeta<string> = '22zoJMtdu4tQc2PzL74ZUT7FrwgB1Udec8DdW4yw4BdG',
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
   IInstructionWithData<Uint8Array> &
@@ -119,9 +123,9 @@ export type CloseAttestationInput<
   authority: TransactionSigner<TAccountAuthority>;
   credential: Address<TAccountCredential>;
   attestation: Address<TAccountAttestation>;
-  eventAuthority: Address<TAccountEventAuthority>;
+  eventAuthority?: Address<TAccountEventAuthority>;
   systemProgram?: Address<TAccountSystemProgram>;
-  attestationProgram: Address<TAccountAttestationProgram>;
+  attestationProgram?: Address<TAccountAttestationProgram>;
 };
 
 export function getCloseAttestationInstruction<
@@ -178,9 +182,17 @@ export function getCloseAttestationInstruction<
   >;
 
   // Resolve default values.
+  if (!accounts.eventAuthority.value) {
+    accounts.eventAuthority.value =
+      'DzSpKpST2TSyrxokMXchFz3G2yn5WEGoxzpGEUDjCX4g' as Address<'DzSpKpST2TSyrxokMXchFz3G2yn5WEGoxzpGEUDjCX4g'>;
+  }
   if (!accounts.systemProgram.value) {
     accounts.systemProgram.value =
       '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
+  }
+  if (!accounts.attestationProgram.value) {
+    accounts.attestationProgram.value =
+      '22zoJMtdu4tQc2PzL74ZUT7FrwgB1Udec8DdW4yw4BdG' as Address<'22zoJMtdu4tQc2PzL74ZUT7FrwgB1Udec8DdW4yw4BdG'>;
   }
 
   const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');

--- a/clients/typescript/src/generated/instructions/closeTokenizedAttestation.ts
+++ b/clients/typescript/src/generated/instructions/closeTokenizedAttestation.ts
@@ -43,11 +43,15 @@ export type CloseTokenizedAttestationInstruction<
   TAccountAuthority extends string | IAccountMeta<string> = string,
   TAccountCredential extends string | IAccountMeta<string> = string,
   TAccountAttestation extends string | IAccountMeta<string> = string,
-  TAccountEventAuthority extends string | IAccountMeta<string> = string,
+  TAccountEventAuthority extends
+    | string
+    | IAccountMeta<string> = 'DzSpKpST2TSyrxokMXchFz3G2yn5WEGoxzpGEUDjCX4g',
   TAccountSystemProgram extends
     | string
     | IAccountMeta<string> = '11111111111111111111111111111111',
-  TAccountAttestationProgram extends string | IAccountMeta<string> = string,
+  TAccountAttestationProgram extends
+    | string
+    | IAccountMeta<string> = '22zoJMtdu4tQc2PzL74ZUT7FrwgB1Udec8DdW4yw4BdG',
   TAccountAttestationMint extends string | IAccountMeta<string> = string,
   TAccountSasPda extends string | IAccountMeta<string> = string,
   TAccountAttestationTokenAccount extends
@@ -55,7 +59,7 @@ export type CloseTokenizedAttestationInstruction<
     | IAccountMeta<string> = string,
   TAccountTokenProgram extends
     | string
-    | IAccountMeta<string> = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    | IAccountMeta<string> = 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
   IInstructionWithData<Uint8Array> &
@@ -148,9 +152,9 @@ export type CloseTokenizedAttestationInput<
   authority: TransactionSigner<TAccountAuthority>;
   credential: Address<TAccountCredential>;
   attestation: Address<TAccountAttestation>;
-  eventAuthority: Address<TAccountEventAuthority>;
+  eventAuthority?: Address<TAccountEventAuthority>;
   systemProgram?: Address<TAccountSystemProgram>;
-  attestationProgram: Address<TAccountAttestationProgram>;
+  attestationProgram?: Address<TAccountAttestationProgram>;
   /** Mint of Attestation Token */
   attestationMint: Address<TAccountAttestationMint>;
   /** Program derived address used as program signer authority */
@@ -233,13 +237,21 @@ export function getCloseTokenizedAttestationInstruction<
   >;
 
   // Resolve default values.
+  if (!accounts.eventAuthority.value) {
+    accounts.eventAuthority.value =
+      'DzSpKpST2TSyrxokMXchFz3G2yn5WEGoxzpGEUDjCX4g' as Address<'DzSpKpST2TSyrxokMXchFz3G2yn5WEGoxzpGEUDjCX4g'>;
+  }
   if (!accounts.systemProgram.value) {
     accounts.systemProgram.value =
       '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
   }
+  if (!accounts.attestationProgram.value) {
+    accounts.attestationProgram.value =
+      '22zoJMtdu4tQc2PzL74ZUT7FrwgB1Udec8DdW4yw4BdG' as Address<'22zoJMtdu4tQc2PzL74ZUT7FrwgB1Udec8DdW4yw4BdG'>;
+  }
   if (!accounts.tokenProgram.value) {
     accounts.tokenProgram.value =
-      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' as Address<'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'>;
+      'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb' as Address<'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb'>;
   }
 
   const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');

--- a/clients/typescript/src/generated/instructions/createTokenizedAttestation.ts
+++ b/clients/typescript/src/generated/instructions/createTokenizedAttestation.ts
@@ -69,8 +69,10 @@ export type CreateTokenizedAttestationInstruction<
   TAccountRecipient extends string | IAccountMeta<string> = string,
   TAccountTokenProgram extends
     | string
-    | IAccountMeta<string> = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
-  TAccountAssociatedTokenProgram extends string | IAccountMeta<string> = string,
+    | IAccountMeta<string> = 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+  TAccountAssociatedTokenProgram extends
+    | string
+    | IAccountMeta<string> = 'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL',
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
   IInstructionWithData<Uint8Array> &
@@ -219,7 +221,7 @@ export type CreateTokenizedAttestationInput<
   /** Wallet to receive Attestation Token */
   recipient: Address<TAccountRecipient>;
   tokenProgram?: Address<TAccountTokenProgram>;
-  associatedTokenProgram: Address<TAccountAssociatedTokenProgram>;
+  associatedTokenProgram?: Address<TAccountAssociatedTokenProgram>;
   nonce: CreateTokenizedAttestationInstructionDataArgs['nonce'];
   data: CreateTokenizedAttestationInstructionDataArgs['data'];
   expiry: CreateTokenizedAttestationInstructionDataArgs['expiry'];
@@ -319,7 +321,11 @@ export function getCreateTokenizedAttestationInstruction<
   }
   if (!accounts.tokenProgram.value) {
     accounts.tokenProgram.value =
-      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' as Address<'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'>;
+      'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb' as Address<'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb'>;
+  }
+  if (!accounts.associatedTokenProgram.value) {
+    accounts.associatedTokenProgram.value =
+      'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL' as Address<'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL'>;
   }
 
   const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');

--- a/clients/typescript/src/generated/instructions/emitEvent.ts
+++ b/clients/typescript/src/generated/instructions/emitEvent.ts
@@ -36,7 +36,9 @@ export function getEmitEventDiscriminatorBytes() {
 
 export type EmitEventInstruction<
   TProgram extends string = typeof SOLANA_ATTESTATION_SERVICE_PROGRAM_ADDRESS,
-  TAccountEventAuthority extends string | IAccountMeta<string> = string,
+  TAccountEventAuthority extends
+    | string
+    | IAccountMeta<string> = 'DzSpKpST2TSyrxokMXchFz3G2yn5WEGoxzpGEUDjCX4g',
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
   IInstructionWithData<Uint8Array> &
@@ -76,7 +78,7 @@ export function getEmitEventInstructionDataCodec(): Codec<
 }
 
 export type EmitEventInput<TAccountEventAuthority extends string = string> = {
-  eventAuthority: TransactionSigner<TAccountEventAuthority>;
+  eventAuthority?: TransactionSigner<TAccountEventAuthority>;
 };
 
 export function getEmitEventInstruction<
@@ -99,6 +101,12 @@ export function getEmitEventInstruction<
     keyof typeof originalAccounts,
     ResolvedAccount
   >;
+
+  // Resolve default values.
+  if (!accounts.eventAuthority.value) {
+    accounts.eventAuthority.value =
+      'DzSpKpST2TSyrxokMXchFz3G2yn5WEGoxzpGEUDjCX4g' as Address<'DzSpKpST2TSyrxokMXchFz3G2yn5WEGoxzpGEUDjCX4g'>;
+  }
 
   const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
   const instruction = {

--- a/clients/typescript/src/generated/instructions/tokenizeSchema.ts
+++ b/clients/typescript/src/generated/instructions/tokenizeSchema.ts
@@ -52,7 +52,7 @@ export type TokenizeSchemaInstruction<
     | IAccountMeta<string> = '11111111111111111111111111111111',
   TAccountTokenProgram extends
     | string
-    | IAccountMeta<string> = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    | IAccountMeta<string> = 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
   IInstructionWithData<Uint8Array> &
@@ -210,7 +210,7 @@ export function getTokenizeSchemaInstruction<
   }
   if (!accounts.tokenProgram.value) {
     accounts.tokenProgram.value =
-      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' as Address<'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'>;
+      'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb' as Address<'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb'>;
   }
 
   const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');

--- a/scripts/generate-clients.js
+++ b/scripts/generate-clients.js
@@ -4,6 +4,11 @@ const path = require("path");
 const renderers = require("@codama/renderers");
 const fs = require("fs");
 
+const TOKEN_2022_PROGRAM_ID = 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb';
+const SAS_PROGRAM_ID = '22zoJMtdu4tQc2PzL74ZUT7FrwgB1Udec8DdW4yw4BdG';
+const ATA_PROGRAM_ID = 'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL';
+const EVENT_AUTHORITY_PDA = 'DzSpKpST2TSyrxokMXchFz3G2yn5WEGoxzpGEUDjCX4g';
+
 const projectRoot = path.join(__dirname, "..");
 const idlDir = path.join(projectRoot, "idl");
 const sasIdl = require(path.join(idlDir, "solana_attestation_service.json"));
@@ -18,17 +23,17 @@ const typescriptClientsDir = path.join(
 function preserveConfigFiles() {
   const filesToPreserve = ['package.json', 'tsconfig.json', '.npmignore', 'pnpm-lock.yaml', 'Cargo.toml'];
   const preservedFiles = new Map();
-  
+
   filesToPreserve.forEach(filename => {
     const filePath = path.join(typescriptClientsDir, filename);
     const tempPath = path.join(typescriptClientsDir, `${filename}.temp`);
-    
+
     if (fs.existsSync(filePath)) {
       fs.copyFileSync(filePath, tempPath);
       preservedFiles.set(filename, tempPath);
     }
   });
-  
+
   return {
     restore: () => {
       preservedFiles.forEach((tempPath, filename) => {
@@ -66,6 +71,27 @@ sasCodama.update(
         };
       },
     },
+  ]),
+);
+
+sasCodama.update(
+  codama.setInstructionAccountDefaultValuesVisitor([
+    {
+      account: 'tokenProgram',
+      defaultValue: codama.publicKeyValueNode(TOKEN_2022_PROGRAM_ID)
+    },
+    {
+      account: 'attestationProgram',
+      defaultValue: codama.publicKeyValueNode(SAS_PROGRAM_ID)
+    },
+    {
+      account: 'associatedTokenProgram',
+      defaultValue: codama.publicKeyValueNode(ATA_PROGRAM_ID)
+    },
+    {
+      account: 'eventAuthority',
+      defaultValue: codama.publicKeyValueNode(EVENT_AUTHORITY_PDA)
+    }
   ]),
 );
 


### PR DESCRIPTION
Updated the client generation script to correct/inject default accounts for key accounts:

- Fix `tokenProgram` defaulting to wrong program (Token vs Token 2022) - Fixes #85
- Add defaults for `attestationProgram`, `associatedTokenProgram`, `eventAuthority`

This improves developer experience by reducing the need to specify these accounts explicitly when using the generated clients.

### Changes
- [scripts/generate-client.js](https://github.com/solana-foundation/solana-attestation-service/blob/master/scripts/generate-clients.js)
- TypeScript Client (autogenerated content)
- Rust Client (autogenerated content)

