### PR TITLE
fix: update test path in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Run integration tests with the following script
 
 ```
-cargo-build-sbf && SBF_OUT_DIR=$(pwd)/target/sbf-solana-solana/release cargo test
+cargo-build-sbf && SBF_OUT_DIR=$(pwd)/target/sbpf-solana-solana/release cargo test
 ```
 
 ## Generating IDL


### PR DESCRIPTION
Update readme so test command points to correct target directory:

> The new `cargo-build-sbf` version target defaults to `sbpf-solana-solana`. The generated programs will be available on `target/deploy` and `target/sbpf-solana-solana/release`.
> 
> [Ref: Agave Changelog](https://github.com/anza-xyz/agave/blob/57b252c3f603e28035c224b36c3cb559ff6f9c87/CHANGELOG.md?plain=1#L71)